### PR TITLE
liquity fallback w/ tellor on mainnet

### DIFF
--- a/src/core/dNFT.sol
+++ b/src/core/dNFT.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-import {IAggregatorV3} from "../interfaces/AggregatorV3Interface.sol";
+import {IPriceFeed} from "../interfaces/IPriceFeed.sol";
 import {DYAD} from "./Dyad.sol";
 
 struct Nft {
@@ -63,7 +63,7 @@ contract dNFT is ERC721Enumerable, ERC721Burnable, ReentrancyGuard {
   mapping(uint => Nft) public idToNft;
 
   DYAD public dyad;
-  IAggregatorV3 internal oracle;
+  IPriceFeed internal oracle;
 
   // Protocol can be in two modes:
   // - BURNING: Price of ETH went down
@@ -114,7 +114,7 @@ contract dNFT is ERC721Enumerable, ERC721Burnable, ReentrancyGuard {
     address[] memory _insiders
   ) ERC721("DYAD NFT", "dNFT") {
     dyad                      = DYAD(_dyad);
-    oracle                    = IAggregatorV3(_oracle);
+    oracle                    = IPriceFeed(_oracle);
     lastEthPrice              = _getLatestEthPrice();
     MIN_COLLATERIZATION_RATIO = _minCollaterizationRatio;
     DEPOSIT_MINIMUM           = _depositMinimum;
@@ -127,9 +127,8 @@ contract dNFT is ERC721Enumerable, ERC721Burnable, ReentrancyGuard {
   }
 
   // ETH price in USD
-  function _getLatestEthPrice() internal view returns (uint) {
-    ( , int newEthPrice, , , ) = oracle.latestRoundData();
-    return uint(newEthPrice);
+  function _getLatestEthPrice() internal returns (uint) {
+    return oracle.fetchPrice();
   }
 
   // The following functions are overrides required by Solidity.

--- a/src/core/dNFT.sol
+++ b/src/core/dNFT.sol
@@ -128,7 +128,7 @@ contract dNFT is ERC721Enumerable, ERC721Burnable, ReentrancyGuard {
 
   // ETH price in USD
   function _getLatestEthPrice() internal returns (uint) {
-    return oracle.fetchPrice();
+    return oracle.fetchPrice() / 1e10; //account for difference in expected sig digs
   }
 
   // The following functions are overrides required by Solidity.

--- a/src/interfaces/IPriceFeed.sol
+++ b/src/interfaces/IPriceFeed.sol
@@ -9,4 +9,6 @@ interface IPriceFeed {
    
     // --- Function ---
     function fetchPrice() external returns (uint);
+
+    function lastGoodPrice() external returns (uint);
 }

--- a/src/interfaces/IPriceFeed.sol
+++ b/src/interfaces/IPriceFeed.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.11;
+
+interface IPriceFeed {
+
+    // --- Events ---
+    event LastGoodPriceUpdated(uint _lastGoodPrice);
+   
+    // --- Function ---
+    function fetchPrice() external returns (uint);
+}

--- a/test/Launch.t.sol
+++ b/test/Launch.t.sol
@@ -16,7 +16,7 @@ interface CheatCodes {
    function addr(uint256) external returns (address);
 }
 
-address constant CHAINLINK_ORACLE_ADDRESS = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+address constant CHAINLINK_TELLOR_FALLBACK = 0x4c517D4e2C851CA76d7eC94B805269Df0f2201De;
 uint constant DEPOSIT_MINIMUM = 5000000000000000000000;
 
 // this should simulate the inital lauch on mainnet
@@ -39,7 +39,7 @@ contract LaunchTest is Test, Parameters, Deployment {
   function setUp() public {
     address _dnft;
     address _dyad;
-    (_dnft,_dyad) = deploy(CHAINLINK_ORACLE_ADDRESS,
+    (_dnft,_dyad) = deploy(CHAINLINK_TELLOR_FALLBACK,
                                  DEPOSIT_MINIMUM,
                                  BLOCKS_BETWEEN_SYNCS, 
                                  MIN_COLLATERIZATION_RATIO, 

--- a/test/Oracle.t.sol
+++ b/test/Oracle.t.sol
@@ -8,15 +8,10 @@ contract OracleMock {
   // 95000000  -> - 5%
   // 110000000 -> +10%
   // 100000000 -> +-0%
-  int public price = 0;
+  uint public price = 0;
 
-  function latestRoundData() public view returns (
-      uint80 roundId,
-      int256 answer,
-      uint256 startedAt,
-      uint256 updatedAt,
-      uint80 answeredInRound
-    ) {
-      return (1, price, 1, 1, 1);  
-    }
+  function fetchPrice() external view returns (uint)  {
+
+    return price;
+  }
 }

--- a/test/Oracle.t.sol
+++ b/test/Oracle.t.sol
@@ -1,6 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import "forge-std/Test.sol";
+import "../src/core/Dyad.sol";
+import {IdNFT} from "../src/interfaces/IdNFT.sol";
+import {dNFT} from "../src/core/dNFT.sol";
+import {OracleMock} from "./Oracle.t.sol";
+import {Util} from "./util/Util.sol";
+import {Deployment} from "../script/Deployment.sol";
+import {Parameters} from "../script/Parameters.sol";
+import {ITellor} from "test/interfaces/ITellor.sol";
+import {IPriceFeed} from "../src/interfaces/IPriceFeed.sol";
+
+address constant CHAINLINK_TELLOR_FALLBACK = 0x4c517D4e2C851CA76d7eC94B805269Df0f2201De;
+address constant TELLOR_TOKEN = 0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0;
+address constant TELLOR_ORACLE = 0xB3B662644F8d3138df63D2F43068ea621e2981f9;
+uint constant DEPOSIT_MINIMUM = 5000000000000000000000;
+
+address constant BIG_HOLDER = 0x39E419bA25196794B595B2a595Ea8E527ddC9856;
+
+
 contract OracleMock {
   // NOTE: this value has to be overwritten in the tests
   // 
@@ -12,6 +31,64 @@ contract OracleMock {
 
   function fetchPrice() external view returns (uint)  {
 
-    return price;
+    return price * 1e10; //liquity values = val * 1e18, whereas dyad oracle values in tests are val * 1e10
   }
+}
+
+contract OracleTest is Test, Deployment, Util, Parameters {
+
+  IdNFT public dnft;
+  DYAD public dyad;
+  ITellor public token;
+  ITellor public oracle;
+
+  IPriceFeed public liquityPriceFeed;
+
+  function setUp() public {
+    address _dnft;
+    address _dyad;
+    (_dnft,_dyad) = deploy(CHAINLINK_TELLOR_FALLBACK,
+                                 DEPOSIT_MINIMUM,
+                                 BLOCKS_BETWEEN_SYNCS, 
+                                 MIN_COLLATERIZATION_RATIO, 
+                                 MAX_SUPPLY,
+                                 new address[](0));
+    dnft = IdNFT(_dnft);
+    dyad = DYAD(_dyad);
+
+    token = ITellor(TELLOR_TOKEN);
+    oracle = ITellor(TELLOR_ORACLE);
+
+    liquityPriceFeed = IPriceFeed(CHAINLINK_TELLOR_FALLBACK);
+
+  }
+
+  function testPriceFeed() public {
+
+    uint oldPrice = liquityPriceFeed.fetchPrice();
+
+    assertGe(oldPrice, 1e18);
+
+    vm.startPrank(BIG_HOLDER);
+
+    IERC20(TELLOR_TOKEN).approve(TELLOR_ORACLE, 1000e18);
+
+    //deposit stake
+    oracle.depositStake(1000e18);
+
+    //submit a value
+    bytes memory queryData = abi.encode("SpotPrice", abi.encode("eth", "usd"));
+    bytes32 queryId = keccak256(queryData);
+
+    skip(60 * 60 * 4 + 1);
+
+
+    oracle.submitValue(queryId, abi.encode(1200e18), 0, queryData);
+
+    skip(60 * 15 + 1);
+
+    uint newPrice = liquityPriceFeed.fetchPrice();
+    assertEq(newPrice, 1200e18);    
+  }
+
 }

--- a/test/interfaces/ITellor.sol
+++ b/test/interfaces/ITellor.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8.0;
+
+interface ITellor {
+    function balanceOf(address) external view returns (uint256);
+    function submitValue(bytes32 _queryId, bytes calldata _value, uint256 _nonce, bytes memory _queryData) external;
+    function depositStake(uint256 _amount) external;
+}


### PR DESCRIPTION
Implements framework that reads Eth/Usd updates from liquity's mainnet `PriceFeed` using their `IPriceFeed` interface.

Includes adjustment to significant digits between what Dyad contracts expect and what Liquity's PriceFeed returns.
All tests pass